### PR TITLE
Fixed a compatibility issue that prevented this extension from working with other extensions that register text editor commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.3.2] - 2025-03-23
+### Fixed
+- Fixed a compatibility issue that prevented this extension from working with other extensions that register text editor commands.  
+
 ## [1.3.1] - 2025-01-24
 ### Changed
 - All different types of quotes are no longer inserted at the end of the selection, so they will work as the standard VS Code behavior

--- a/extension.js
+++ b/extension.js
@@ -36,7 +36,7 @@ function activate(context) {
 	);
 
 	const typeDisposable = vscode.commands.registerTextEditorCommand(
-		"type",
+		"selectPastedText.type",
 		(textEditor, edit, args) => {
 			// Special characters that should not trigger selection clearing
 			const specialCharacters = ["(", "[", "{", '"', "'", "`"];


### PR DESCRIPTION
## 📝 Description
Fixed a compatibility issue that prevented this extension from working with other extensions that register text editor commands. (first encountered as a compatibility issue with vscodevim, as seen in the screenshots below)

![fix](https://github.com/user-attachments/assets/20bb81c4-63e5-4e4a-82c7-037fa60f7db8)
![Screenshot_3](https://github.com/user-attachments/assets/d626040e-a0a3-4b4c-a873-b1795d62d58b)

This change is required because it increases compatibility with other extensions focused on text editor commands, and 

## ✅ Checklist
- [x] I have made the type command non-generic
- [x] I have tested the extension still works
- [x] I have tested the compatibility issue is fixed
- [x] I have added to the changelog