### PR TITLE
Added a config option to allow the user to disable inserting the character after selection in exchange for compatibility with Vim for Vscode

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -53,8 +53,8 @@ function activate(context) {
 
 	//Fixes incompatibility related to both extensions attempting to overwrite the type command
 	const config = vscode.workspace.getConfiguration('select-pasted-text');
-    const isVimFixEnabled = config.get('vscodevimfix');
-	if(!isVimFixEnabled)
+    const isTypeCompatibilityFixEnabled = config.get('typeCommandCompatibilityFix');
+	if(!isTypeCompatibilityFixEnabled)
 	{
 		const typeDisposable = vscode.commands.registerTextEditorCommand(
 			"type",

--- a/extension.js
+++ b/extension.js
@@ -53,8 +53,8 @@ function activate(context) {
 
 	//Fixes incompatibility related to both extensions attempting to overwrite the type command
 	const config = vscode.workspace.getConfiguration('selectPastedText');
-    const isTypeCompatibilityFixEnabled = config.get('typeCommandCompatibilityFix');
-	if(!isTypeCompatibilityFixEnabled)
+    const isTypeCommandCompatibilityFixEnabled = config.get('typeCommandCompatibilityFix');
+	if(!isTypeCommandCompatibilityFixEnabled)
 	{
 		const typeDisposable = vscode.commands.registerTextEditorCommand(
 			"type",

--- a/extension.js
+++ b/extension.js
@@ -52,7 +52,7 @@ function activate(context) {
 	context.subscriptions.push(selectionChangeDisposable);
 
 	//Fixes incompatibility related to both extensions attempting to overwrite the type command
-	const config = vscode.workspace.getConfiguration('select-pasted-text');
+	const config = vscode.workspace.getConfiguration('selectPastedText');
     const isTypeCompatibilityFixEnabled = config.get('typeCommandCompatibilityFix');
 	if(!isTypeCompatibilityFixEnabled)
 	{

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
 		"configuration": {
 			"type": "object",
 			"properties": {
-				"select-pasted-text.vscodevimfix": {
+				"select-pasted-text.typeCommandCompatibilityFix": {
 					"type": "boolean",
 					"default": false,
-					"description": "(Requires extension restart) This fix resolves a compatibility issue with Vim for VSCode; however, it disables the behavior that appends the next keystroke at the end of the selection—instead, the keystroke overwrites the selection."
+					"description": "(Requires extension restart) This fix resolves a compatibility issue with extensions that overwrite the type command; however, it disables the behavior that appends the next keystroke at the end of the selection—instead, the keystroke overwrites the selection."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"configuration": {
 			"type": "object",
 			"properties": {
-				"select-pasted-text.typeCommandCompatibilityFix": {
+				"selectPastedText.typeCommandCompatibilityFix": {
 					"type": "boolean",
 					"default": false,
 					"description": "(Requires extension restart) This fix resolves a compatibility issue with extensions that overwrite the type command; however, it disables the behavior that appends the next keystroke at the end of the selection—instead, the keystroke overwrites the selection."

--- a/package.json
+++ b/package.json
@@ -33,7 +33,17 @@
 				"key": "cmd+v",
 				"when": "editorTextFocus && isMac"
 			}
-		]
+		],
+		"configuration": {
+			"type": "object",
+			"properties": {
+				"select-pasted-text.vscodevimfix": {
+					"type": "boolean",
+					"default": false,
+					"description": "(Requires extension restart) This fix resolves a compatibility issue with Vim for VSCode; however, it disables the behavior that appends the next keystroke at the end of the selection—instead, the keystroke overwrites the selection."
+				}
+			}
+		}
 	},
 	"scripts": {
 		"lint": "eslint .",


### PR DESCRIPTION
If there isn't another way to fix this, what do you think of:
![image](https://github.com/user-attachments/assets/3a6d670f-cd9c-4337-9f13-80c708d06e4b)
